### PR TITLE
Cast current to integer

### DIFF
--- a/addon/components/pagination-pager.js
+++ b/addon/components/pagination-pager.js
@@ -18,11 +18,19 @@ export default Component.extend({
   countOut: 2,
   countIn: 2,
   firstPage: 1,
-  current: 1,
   urlTemplate: '#',
   firstPageUrlTemplate: null,
   lastPage: alias('count'),
 
+  current: computed({
+    set(k,v) {
+      return parseInt(v);
+    },
+    get(k) {
+      return 1;
+    }
+  }),
+  
   previousUrl: computed('urlTemplate', 'current', 'firstPage', function () {
     let urlTemplate = this.get('urlTemplate');
     let current = this.get('current');


### PR DESCRIPTION
`current` could be string as it could be sourced in query params. In case current is `string` component behaviour is broken. This pull request casts `current` to `integer` . I think it is even related to issue #24

To reproduce use this config, make current as string 

`count=72`
`current='32'`
